### PR TITLE
pollTimer was still problematic. should be fixed now

### DIFF
--- a/ModbusMaster/MasterForm.Designer.cs
+++ b/ModbusMaster/MasterForm.Designer.cs
@@ -265,5 +265,6 @@
         private System.Windows.Forms.TextBox txtPollDelay;
         private System.Windows.Forms.CheckBox cbPoll;
         private System.Windows.Forms.Timer pollTimer;
+        private System.ComponentModel.IContainer components;
     }
 }

--- a/ModbusMaster/MasterForm.resx
+++ b/ModbusMaster/MasterForm.resx
@@ -123,6 +123,9 @@
   <metadata name="saveFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>150, 17</value>
   </metadata>
+  <metadata name="pollTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1, 20</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
The pollTimer issues kept living on, preventing a fresh clone of the repository to compile. It seems that for some time the MasterForm.Designer.cs and MasterForm.rex file contents have been fighting. 

Looking back it seems my initial contribution regarding the MasterForm polling timer didn't include every required change.

Yet I can't even see why the solution kept building in Visual Studio. On a new computer, it didn't

2020-06-10 a0f61189fc177cee6c514c00e280027a3d34b3f2
1st introduction of the polling timer, in .Designer.cs only, but the components container wasn't included

2020-06-14 ab53f66cbd87e81efa5dee7e35df5ebb0ff41348
a Resx update removed the definition "private System.ComponentModel.IContainer components = null;" from .Designer.cs

2020-07-27 7eb0dac6be4b38a32ef1fe0c1cdd989023cf73f6 
a resx update removed pollTimer definistion from .Designer.cs and .resx

2020-08-08 0b84aedeb932a6794bb1321573c8ee53fe69f684
Poll timer restored in .Designer.cs ONLY
