### PR TITLE
Upgrade projects from net452 to net48

### DIFF
--- a/CommonControls/Modbus.Common.csproj
+++ b/CommonControls/Modbus.Common.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Modbus.Common</RootNamespace>
     <AssemblyName>Modbus.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/CommonControls/app.config
+++ b/CommonControls/app.config
@@ -51,4 +51,4 @@
             </setting>
         </Modbus.Common.Properties.Settings>
     </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/ModbusLib/ModbusLib.csproj
+++ b/ModbusLib/ModbusLib.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ModbusLib</RootNamespace>
     <AssemblyName>ModbusLib</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/ModbusMaster/ModbusMaster.csproj
+++ b/ModbusMaster/ModbusMaster.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ModbusMaster</RootNamespace>
     <AssemblyName>ModbusMaster</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/ModbusMaster/app.config
+++ b/ModbusMaster/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
 
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup>
 
 </configuration>

--- a/ModbusSlave/ModbusSlave.csproj
+++ b/ModbusSlave/ModbusSlave.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ModbusSlave</RootNamespace>
     <AssemblyName>ModbusSlave</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/ModbusSlave/app.config
+++ b/ModbusSlave/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
With a fresh install of VS2022 I'm not able to run net framework 4.5.2 projects. Your current projects framework version was deprecated in 2016. 
- The aim of this PR is to upgrade to [.NET Framework 4.8](https://dotnet.microsoft.com/es-es/download/dotnet-framework/net48) which is still supported by Microsoft.
- It's a simple modification that allows everyone to clone and run the applicacions with latest Visual Studio.
