### PR TITLE
Fix window size to prevent resizing breaking layout

### DIFF
--- a/ModbusMaster/MasterForm.Designer.cs
+++ b/ModbusMaster/MasterForm.Designer.cs
@@ -218,7 +218,10 @@
             this.Controls.Add(this.buttonDisconnect);
             this.Controls.Add(this.btnConnect);
             this.Controls.Add(this.groupBoxFunctions);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "MasterForm";
             this.ShowDataLength = true;
             this.Text = "Modbus Master";

--- a/ModbusSlave/SlaveForm.Designer.cs
+++ b/ModbusSlave/SlaveForm.Designer.cs
@@ -68,7 +68,10 @@
             this.ClientSize = new System.Drawing.Size(869, 887);
             this.Controls.Add(this.buttonDisconnect);
             this.Controls.Add(this.btnConnect);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "SlaveForm";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.SlaveFormClosing);
             this.Load += new System.EventHandler(this.SlaveFormLoading);


### PR DESCRIPTION
Fixes https://github.com/ClassicDIY/ModbusTool/issues/42

- Disables maximize/minimize buttons
- Disables resizing window

<img width="653" alt="image" src="https://github.com/user-attachments/assets/199eba84-7321-460a-bfeb-bf8619b433fa">
