### PR TITLE
Skip polling if disconnected

### DIFF
--- a/ModbusMaster/MasterForm.cs
+++ b/ModbusMaster/MasterForm.cs
@@ -272,6 +272,10 @@ namespace ModbusMaster
 
         private void pollTimer_Tick(object sender, EventArgs e)
         {
+            // disconnected state, skip
+            if (groupBoxFunctions.Enabled == false)
+                return;
+
             if (_lastReadCommand != 0)
                 ExecuteReadCommand(_lastReadCommand);
         }


### PR DESCRIPTION
Fixes #44

Alternatively another fix could be to disable the poll timer from the connect/disconnect button callback, but it felt a bit too verbose

```diff
        private void BtnConnectClick(object sender, EventArgs e)
        {
            ...
            btnConnect.Enabled = false;
            buttonDisconnect.Enabled = true;
            groupBoxFunctions.Enabled = true;
+           pollTimer.Enabled = cbPoll.Checked;
            groupBoxTCP.Enabled = false;
            groupBoxRTU.Enabled = false;
            groupBoxMode.Enabled = false;
            grpExchange.Enabled = false;
        }

        private void ButtonDisconnectClick(object sender, EventArgs e)
        {
            DoDisconnect();
            btnConnect.Enabled = true;
            buttonDisconnect.Enabled = false;
            groupBoxFunctions.Enabled = false;
            groupBoxMode.Enabled = true;
+           pollTimer.Enabled = false;
            grpExchange.Enabled = true;
            SetMode();
            AppendLog("Disconnected");
        }
```