### PR TITLE
Re-enable resizeable window, fix clipping

### DIFF
--- a/ModbusMaster/MasterForm.Designer.cs
+++ b/ModbusMaster/MasterForm.Designer.cs
@@ -63,6 +63,10 @@
             this.radioButtonInteger.Location = new System.Drawing.Point(86, 20);
             this.radioButtonInteger.Size = new System.Drawing.Size(64, 21);
             // 
+            // grpStart
+            // 
+            this.grpStart.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            // 
             // label1
             // 
             this.label1.Visible = false;
@@ -214,14 +218,12 @@
             // MasterForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScroll = true;
             this.ClientSize = new System.Drawing.Size(869, 917);
             this.Controls.Add(this.buttonDisconnect);
             this.Controls.Add(this.btnConnect);
             this.Controls.Add(this.groupBoxFunctions);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
             this.Name = "MasterForm";
             this.ShowDataLength = true;
             this.Text = "Modbus Master";

--- a/ModbusSlave/SlaveForm.Designer.cs
+++ b/ModbusSlave/SlaveForm.Designer.cs
@@ -36,6 +36,10 @@
             this.grpExchange.SuspendLayout();
             this.SuspendLayout();
             // 
+            // grpStart
+            // 
+            this.grpStart.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            // 
             // label8
             // 
             this.label8.Visible = false;
@@ -65,13 +69,11 @@
             // SlaveForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.ClientSize = new System.Drawing.Size(869, 887);
+            this.AutoScroll = true;
+            this.ClientSize = new System.Drawing.Size(869, 896);
             this.Controls.Add(this.buttonDisconnect);
             this.Controls.Add(this.btnConnect);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
             this.Name = "SlaveForm";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.SlaveFormClosing);
             this.Load += new System.EventHandler(this.SlaveFormLoading);


### PR DESCRIPTION
Reverts the change in https://github.com/ClassicDIY/ModbusTool/pull/43
Fixes https://github.com/ClassicDIY/ModbusTool/issues/46 
Fixes https://github.com/ClassicDIY/ModbusTool/issues/33

Re-enable minimize (sorry should have never disabled that), maximize buttons. 
Fixes the clipping issue when scaling the window width smaller.
Adds scrollbars to window if smaller than content size.

Example when window is bigger

![Screenshot 2024-08-15 210227](https://github.com/user-attachments/assets/e97a8b4a-9211-4450-9ba1-b4c61463c2f8)

Example when window is smaller

https://github.com/user-attachments/assets/9af79798-9ed9-4719-9121-225179317ef5

